### PR TITLE
Expand leaf arrays that have only one value in it

### DIFF
--- a/lib/bukelatta/dsl/context.rb
+++ b/lib/bukelatta/dsl/context.rb
@@ -8,6 +8,7 @@ class Bukelatta::DSL::Context
   end
 
   def result
+    expand_leaf_array!
     @result.sort_array!
   end
 
@@ -51,5 +52,32 @@ class Bukelatta::DSL::Context
     end
 
     @result[name] = yield
+  end
+
+  def expand_leaf_array!
+    @result = expand_leaf_array(@result)
+  end
+
+  def expand_leaf_array(obj)
+    case obj
+    when Array
+      if obj[0].instance_of?(Array) || obj[0].instance_of?(Hash)
+        return obj.map do |o|
+          expand_leaf_array(o)
+        end
+      end
+      # Leaf
+      if obj.length == 1
+        return obj[0]
+      end
+      return obj
+    when Hash
+      h = {}
+      obj.each do |k, v|
+        h[k] = expand_leaf_array(v)
+      end
+      return h
+    end
+    return obj
   end
 end


### PR DESCRIPTION
Suppose a bucket policy below, `aws:SourceIp` can be specified as a string or an array of strings.

```ruby
bucket 'bbb' do
  {
    'Version' => '2012-10-17',
    'Id' => 'PolicyXXX',
    'Statement' => [
      {
        'Sid' => 'StmtXXX',
        'Effect' => 'Allow',
        'Principal' => '*',
        'Action' => 's3:GetObject',
        'Resource' => 'arn:aws:s3:::bbb/*',
        'Condition' => {
          'IpAddress' => {
            'aws:SourceIp' => [
              '1.1.1.1/32',
            ],
          },
        },
      },
    ],
  }
end
```

Here
```ruby
'IpAddress' => {
  'aws:SourceIp' => '1.1.1.1/32',
},
```
and
```ruby
'IpAddress' => {
  'aws:SourceIp' => [
    '1.1.1.1/32',
  ],
},
```
have the same meaning.

In either case, an array that has only one value will be expanded to the value (like `'aws:SourceIp' => '1.1.1.1/32'`) by AWS.
Then bukelatta detects a difference between (expanded) bucket policy and the policy file.

This patch imitates AWS auto conversion just before sorting, by expanding arrays when:
* the array is a leaf of the bucket policy structure
* the array has exactly one value in it

In environments I'm managing has no problem (nor diff) with this patch, could you check the patch on your side please?