### PR TITLE
Stringify Policy Keys and support pass bucket name

### DIFF
--- a/lib/bukelatta/dsl/context.rb
+++ b/lib/bukelatta/dsl/context.rb
@@ -50,6 +50,6 @@ class Bukelatta::DSL::Context
       raise "Bucket `#{name}` is already defined"
     end
 
-    @result[name] = yield
+    @result[name] = Hashie.stringify_keys yield(name)
   end
 end


### PR DESCRIPTION
A bit more syntactic sugar to support:

```
bucket "my-bucket" do |bkt|
  { Version: "2012-10-17",
    Statement: [
      { Effect: "Allow",
        Principal: "*",
        Action: "s3:getObject",
        Resource: "arn:aws:s3:::#{bkt}/*" } ] }
end
```